### PR TITLE
Use configurable URL in API/Viz calls

### DIFF
--- a/src/components/AnalysisContent/index.js
+++ b/src/components/AnalysisContent/index.js
@@ -139,6 +139,7 @@ function AnalysisContent({ classes, content, topicIndex, takwimu, onChange }) {
             key={topicIndex}
             data={content.body[topicIndex].value.body}
             onIndexChanged={setCarouselItemIndex}
+            url={takwimu.url}
           />
         ) : (
           <Grid container direction="row">
@@ -155,6 +156,7 @@ function AnalysisContent({ classes, content, topicIndex, takwimu, onChange }) {
                     classes={{ root: classes.dataContainer }}
                     indicator={c}
                     country={takwimu.country}
+                    url={takwimu.url}
                   />
                 )}
               </Fragment>
@@ -221,6 +223,7 @@ AnalysisContent.propTypes = {
   topicIndex: PropTypes.number.isRequired,
   onChange: PropTypes.func.isRequired,
   takwimu: PropTypes.shape({
+    url: PropTypes.string.isRequired,
     page: PropTypes.shape({}).isRequired,
     country: PropTypes.shape({}).isRequired
   }).isRequired

--- a/src/components/AnalysisContent/topics/CarouselTopic.js
+++ b/src/components/AnalysisContent/topics/CarouselTopic.js
@@ -155,7 +155,7 @@ const styles = theme => ({
   }
 });
 
-function Topic({ classes, data, onIndexChanged }) {
+function Topic({ classes, data, onIndexChanged, url }) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [images, setImages] = useState({});
 
@@ -168,7 +168,7 @@ function Topic({ classes, data, onIndexChanged }) {
 
   useEffect(() => {
     data.forEach(item =>
-      fetch(`/api/v2/images/${item.image}`)
+      fetch(`${url}/api/v2/images/${item.image}`)
         .then(response => response.json())
         .then(json =>
           setImages(prev => ({
@@ -177,7 +177,7 @@ function Topic({ classes, data, onIndexChanged }) {
           }))
         )
     );
-  }, [data]);
+  }, [data, url]);
   const { name } = data[selectedIndex];
   let { title } = data[selectedIndex];
   if (name && name.length > 0) {
@@ -264,7 +264,8 @@ Topic.propTypes = {
       title: PropTypes.string
     })
   ).isRequired,
-  onIndexChanged: PropTypes.func.isRequired
+  onIndexChanged: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired
 };
 
 export default withStyles(styles)(Topic);

--- a/src/components/DataContainer/EntitiesDataContainer.js
+++ b/src/components/DataContainer/EntitiesDataContainer.js
@@ -13,14 +13,14 @@ const styles = {
   }
 };
 
-function DataContainer({ id, classes, data, countryName }) {
+function DataContainer({ id, classes, data, countryName, url }) {
   const [images, setImages] = useState({});
 
   useEffect(() => {
     data.entities.forEach(
       entity =>
         entity.image &&
-        fetch(`/api/v2/images/${entity.image}`)
+        fetch(`${url}/api/v2/images/${entity.image}`)
           .then(response => response.json())
           .then(json =>
             setImages(prev => ({
@@ -31,7 +31,7 @@ function DataContainer({ id, classes, data, countryName }) {
     );
 
     return () => {};
-  }, [data.entities]);
+  }, [data.entities, url]);
 
   return (
     <>
@@ -53,7 +53,8 @@ DataContainer.propTypes = {
     title: PropTypes.string
   }).isRequired,
   classes: PropTypes.shape({}).isRequired,
-  countryName: PropTypes.string.isRequired
+  countryName: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired
 };
 
 DataContainer.defaultProps = {

--- a/src/components/DataContainer/FlourishDataContainer.js
+++ b/src/components/DataContainer/FlourishDataContainer.js
@@ -118,6 +118,15 @@ function DataContainer({ id, classes, data, theme, countryName, url }) {
     frameHead.appendChild(style);
   };
 
+  /**
+   * First time the onLoad function is called, we get:
+   * `TypeError: iframe.contentDocument is null`.
+   *
+   * This function is temporary fix to get around that... The downside being
+   * when we do add the second `onLoad` listener, the `load` event could
+   * have been already fired.
+   * @param {*} e .
+   */
   const handleIframeCreated = e => {
     const iframe = e.target;
     iframe.addEventListener('load', handleIframeLoaded);

--- a/src/components/DataContainer/FlourishDataContainer.js
+++ b/src/components/DataContainer/FlourishDataContainer.js
@@ -85,7 +85,6 @@ function DataContainer({ id, classes, data, theme, countryName, url }) {
 
   const handleIframeLoaded = e => {
     const iframe = e.target;
-    console.log('IFRAME', iframe);
     // Most static charts have a wrapper element with id `wrapper`
     const wrapper = iframe.contentDocument.getElementById('wrapper');
     if (wrapper) {

--- a/src/components/DataContainer/FlourishDataContainer.js
+++ b/src/components/DataContainer/FlourishDataContainer.js
@@ -119,6 +119,11 @@ function DataContainer({ id, classes, data, theme, countryName, url }) {
     frameHead.appendChild(style);
   };
 
+  const handleIframeCreated = e => {
+    const iframe = e.target;
+    iframe.addEventListener('load', handleIframeLoaded);
+  };
+
   if (animated) {
     const iframe = document.getElementById(`data-indicator-${id}`);
     updateIframe(iframe, iframe.contentDocument.getElementById(animatedId));
@@ -136,7 +141,7 @@ function DataContainer({ id, classes, data, theme, countryName, url }) {
         frameBorder="0"
         scrolling="no"
         title={data.title}
-        onLoad={handleIframeLoaded}
+        onLoad={handleIframeCreated}
         src={`${url}/flourish/${data.html}`}
         className={classes.root}
       />

--- a/src/components/DataContainer/FlourishDataContainer.js
+++ b/src/components/DataContainer/FlourishDataContainer.js
@@ -13,7 +13,7 @@ const styles = {
   }
 };
 
-function DataContainer({ id, classes, data, theme, countryName }) {
+function DataContainer({ id, classes, data, theme, countryName, url }) {
   const [animated, setAnimated] = useState(false);
   const [animatedId, setAnimatedId] = useState('');
 
@@ -85,6 +85,7 @@ function DataContainer({ id, classes, data, theme, countryName }) {
 
   const handleIframeLoaded = e => {
     const iframe = e.target;
+    console.log('IFRAME', iframe);
     // Most static charts have a wrapper element with id `wrapper`
     const wrapper = iframe.contentDocument.getElementById('wrapper');
     if (wrapper) {
@@ -126,7 +127,7 @@ function DataContainer({ id, classes, data, theme, countryName }) {
   const embedCode = `<iframe title="${data.title}"
  frameborder="0"
  scrolling="no"
- src="https://takwimu.africa/flourish/${data.html}" />`;
+ src="${url}/flourish/${data.html}" />`;
 
   return (
     <>
@@ -135,8 +136,8 @@ function DataContainer({ id, classes, data, theme, countryName }) {
         frameBorder="0"
         scrolling="no"
         title={data.title}
-        src={`/flourish/${data.html}`}
         onLoad={handleIframeLoaded}
+        src={`${url}/flourish/${data.html}`}
         className={classes.root}
       />
       <DataActions
@@ -166,7 +167,8 @@ DataContainer.propTypes = {
     typography: PropTypes.shape({
       fontText: PropTypes.string
     })
-  }).isRequired
+  }).isRequired,
+  url: PropTypes.string.isRequired
 };
 
 DataContainer.defaultProps = {

--- a/src/components/DataContainer/PDFDataContainer.js
+++ b/src/components/DataContainer/PDFDataContainer.js
@@ -21,14 +21,14 @@ const styles = {
   }
 };
 
-function DataContainer({ id, classes, data, countryName }) {
+function DataContainer({ id, classes, data, countryName, url }) {
   const [documents, setDocuments] = useState({});
   const [page, setPage] = useState(1);
   const [numberOfPages, setNumberOfPages] = useState(0);
 
   useEffect(() => {
     if (data.document) {
-      fetch(`/api/v2/documents/${data.document}`)
+      fetch(`${url}/api/v2/documents/${data.document}`)
         .then(response => response.json())
         .then(json =>
           setDocuments(prev => ({
@@ -38,7 +38,7 @@ function DataContainer({ id, classes, data, countryName }) {
         );
     }
     return () => {};
-  }, [data.document]);
+  }, [data.document, url]);
 
   const handleDownload = () => {
     const link = document.createElement('a');
@@ -110,7 +110,8 @@ DataContainer.propTypes = {
   id: PropTypes.string,
   data: PropTypes.shape({}).isRequired,
   classes: PropTypes.shape({}).isRequired,
-  countryName: PropTypes.string.isRequired
+  countryName: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired
 };
 
 DataContainer.defaultProps = {

--- a/src/components/DataContainer/index.js
+++ b/src/components/DataContainer/index.js
@@ -61,7 +61,8 @@ function DataContainer({
     value: { widget: data, summary },
     meta
   },
-  country: { name: countryName }
+  country: { name: countryName },
+  url
 }) {
   useEffect(() => {
     const params = new URL(window.location).searchParams;
@@ -129,6 +130,7 @@ function DataContainer({
               id={id}
               data={data.value}
               countryName={countryName}
+              url={url}
             />
           )}
 
@@ -137,6 +139,7 @@ function DataContainer({
               id={id}
               data={data.value}
               countryName={countryName}
+              url={url}
             />
           )}
 
@@ -145,6 +148,7 @@ function DataContainer({
               id={id}
               data={data.value}
               countryName={countryName}
+              url={url}
             />
           )}
         </Grid>
@@ -190,7 +194,8 @@ DataContainer.propTypes = {
   }).isRequired,
   country: PropTypes.shape({
     name: PropTypes.string.isRequired
-  }).isRequired
+  }).isRequired,
+  url: PropTypes.string.isRequired
 };
 
 DataContainer.defaultProps = {

--- a/src/components/FeaturedData.js
+++ b/src/components/FeaturedData.js
@@ -21,6 +21,7 @@ const styles = () => ({
 function FeaturedData({
   classes,
   takwimu: {
+    url,
     page: {
       featured_data: { value: featuredData }
     }
@@ -49,6 +50,7 @@ function FeaturedData({
             country={{
               name: 'Featured Data'
             }}
+            url={url}
           />
           {indicators.length > 1 && (
             <DataContainer
@@ -59,6 +61,7 @@ function FeaturedData({
               country={{
                 name: 'Featured Data'
               }}
+              url={url}
             />
           )}
         </Grid>
@@ -70,6 +73,7 @@ function FeaturedData({
 FeaturedData.propTypes = {
   classes: PropTypes.shape({}).isRequired,
   takwimu: PropTypes.shape({
+    url: PropTypes.string.isRequired,
     page: PropTypes.shape({
       featured_data: PropTypes.shape({
         value: PropTypes.shape({


### PR DESCRIPTION
## Description

Instead of using hard-coded, relative URLs in API and Viz, use the configurable URL e.g. `https://takwimu.africa`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot_2019-08-28 Takwimu](https://user-images.githubusercontent.com/1779590/63860972-b9330100-c9b2-11e9-8261-708427d92e9e.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation