### PR TITLE
Fix Other Info Navigation

### DIFF
--- a/src/components/AnalysisContent/ContentNavigation.js
+++ b/src/components/AnalysisContent/ContentNavigation.js
@@ -17,9 +17,10 @@ function AnalysisContentNavigation({
   content,
   showContent,
   linksPrimaryColor,
-  linksSecondaryColor
+  linksSecondaryColor,
+  ...props
 }) {
-  const classes = useStyles();
+  const classes = useStyles(props);
   const generateHref = index => {
     const item = content.body[index];
     return `#${item.id}`;

--- a/src/components/AnalysisContent/OtherInfoNav.js
+++ b/src/components/AnalysisContent/OtherInfoNav.js
@@ -17,7 +17,7 @@ const useStyles = makeStyles(theme => ({
     left: 0,
     width: '100%',
     height: '100px',
-    overflow: 'scroll',
+    overflow: 'auto',
     display: 'flex',
     justifyContent: 'center',
     zIndex: 2, // Ensure its ontop (data continer actions has index 1)

--- a/src/components/ContentNavigation.js
+++ b/src/components/ContentNavigation.js
@@ -50,7 +50,7 @@ function ContentNavigation({
   linksSecondaryColor,
   ...props
 }) {
-  const classes = useStyles();
+  const classes = useStyles(props);
   return (
     /* eslint-disable-next-line react/jsx-props-no-spreading */
     <ContentSection classes={{ root: classes.root }} {...props}>


### PR DESCRIPTION
## Description

Fix `Other Info Navigation`:
 - [x] `scroll` should be `auto`, and
 - [x] pass `props` to `useStyle` for overriding styles in Material UI `v4`.
 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot](https://user-images.githubusercontent.com/1779590/64169810-3fd65b00-ce57-11e9-9221-4dea21de5507.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation