### PR TITLE
Add conditions when querying the total_populations table

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://dev.takwimu.africa",
   "dependencies": {
     "@apollo/react-hooks": "^3.0.1",
-    "@codeforafrica/hurumap-ui": "^0.2.0-alpha.7",
+    "@codeforafrica/hurumap-ui": "^0.2.0-alpha.8",
     "@material-ui/core": "^4.5.1",
     "@material-ui/icons": "^4.2.1",
     "@material-ui/styles": "^4.5.0",

--- a/src/config.js
+++ b/src/config.js
@@ -149,7 +149,17 @@ const config = {
     'allPopulationResidence2009S',
     'allPopulationResidence2012S',
     'allPopulationResidence2013S',
-    'allTotalPopulations'
+    /**
+     * Countries have their populations in `allTotalPopulations`
+     * Make sure we retrieve the latest population total
+     */
+    [
+      'allTotalPopulations',
+      {
+        orderBy: 'TOTAL_POPULATION_YEAR_DESC',
+        first: 1
+      }
+    ]
   ]
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,10 +826,10 @@
   resolved "https://registry.yarnpkg.com/@bundled-es-modules/pdfjs-dist/-/pdfjs-dist-2.1.266-rc.tgz#d77562dcec57b94f9533e1a774b30a3880fd583b"
   integrity sha512-idli/i9GA7hUW8uRIs2Y48m5QHKRv3PaVxlM1VEoOuzWoF2qLdtOepOpIy3BTblakDNt2f/gINPN7X/v9DBKoQ==
 
-"@codeforafrica/hurumap-ui@^0.2.0-alpha.7":
-  version "0.2.0-alpha.7"
-  resolved "https://registry.yarnpkg.com/@codeforafrica/hurumap-ui/-/hurumap-ui-0.2.0-alpha.7.tgz#6cd274669f295980ca02706f5e389e763839c185"
-  integrity sha512-zZQKc17eKVF1mlePgGIZbWIEcpuDIVQYtUn3af/OAoWGE6mJA6fwPH0s80DHchW5a0LCUAUPapEP5SHGkt3Zfg==
+"@codeforafrica/hurumap-ui@^0.2.0-alpha.8":
+  version "0.2.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@codeforafrica/hurumap-ui/-/hurumap-ui-0.2.0-alpha.8.tgz#d2e605d710cf120e10ce14e0d3534803b99e176d"
+  integrity sha512-kuhkA5XluZsVESysI+sQDsYNXa+ed7Q53pN82xLVp3k/9KdIQ1TWJoCkEwX9zmdxNgh7CBve60EVhQPP5uZxWQ==
   dependencies:
     "@material-ui/core" "^4.5.1"
     "@material-ui/styles" "^4.5.0"


### PR DESCRIPTION
## Description

- [x] Requires https://github.com/CodeForAfrica/HURUmap-UI/pull/73

When querying total populations table get only one value of the latest year i.e. 2017.
This makes sure [useProfileLoader](https://github.com/CodeForAfrica/HURUmap-UI/blob/a62cacc0498a47432cec137bba23ef047694dd65/src/factory/useProfileLoader/index.js) does not sum up all the years.

The conditions resolves to the following gql which you can test here https://graphql.takwimu.africa/graphiql:

```
{
   allTotalPopulations(orderBy: TOTAL_POPULATION_YEAR_DESC, first: 1, condition:{ geoCode: "CD",  geoLevel: "country" } ) {
    nodes {
      total
    }
  }
}
```

Fixes # (issue)

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation