### PR TITLE
[Hotfix] Don't use theme fonts in Flourish iframe

### DIFF
--- a/src/components/DataContainer/FlourishChart.js
+++ b/src/components/DataContainer/FlourishChart.js
@@ -46,7 +46,6 @@ function FlourishChart({ chartId, charts }) {
       wrapper && wrapper.offsetHeight > 420 ? wrapper.offsetHeight : 420;
     /* eslint-disable no-param-reassign */
     iframe.style.height = `${height}px`;
-    iframe.contentDocument.body.style.fontFamily = theme.typography.fontText;
     iframe.contentDocument.body.style.background = 'rgb(0,0,0) !important';
     /* eslint-enable no-param-reassign */
     const headers = iframe.contentDocument.getElementsByClassName(


### PR DESCRIPTION
## Description

Theme fonts are not available in the `iframe`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

```
Error while reading CSS rules from https://fonts.googleapis.com/css?family=Lora:400,700|Muli:400,700 SecurityError: Failed to read the 'cssRules' property from 'CSSStyleSheet': Cannot access rules
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation