### PR TITLE
Update Analysis getInitialProps function

### DIFF
--- a/src/components/AnalysisPage.js
+++ b/src/components/AnalysisPage.js
@@ -149,7 +149,7 @@ AnalysisPage.getInitialProps = async ({ query, asPath }) => {
         );
 
         const topics = await Promise.all(
-          sectionTopics.map(async ({ profile_section_topic: topic }) => {
+          sectionTopics.map(async topic => {
             if (topic.post_content === '') {
               topic.type = 'carousel_topic'; // eslint-disable-line no-param-reassign
               // add another backend call to fetch the carousel_topic

--- a/src/components/AnalysisPage.js
+++ b/src/components/AnalysisPage.js
@@ -184,8 +184,6 @@ AnalysisPage.getInitialProps = async ({ query, asPath }) => {
 
   const analysisLink = `${config.url}${asPath}`;
 
-  console.log(config);
-
   return {
     takwimu: config,
     activeAnalysis,


### PR DESCRIPTION
## Description

We have moved from using `acf repeater` field to using `acf relationship` field on wordpress for children topics of a profile section. This has in-turn changed the analysis json object structure. This PR updates the `getInitialProps` of analysis-page to correspond with the acf structure changes

Fixes [#170569389](https://www.pivotaltracker.com/story/show/170569389)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation