### PR TITLE
[Hotfix] Switch to Custom error page

### DIFF
--- a/src/pages/[page]/index.js
+++ b/src/pages/[page]/index.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTyes from 'prop-types';
 import Head from 'next/head';
-import ErrorPage from 'next/error';
+import ErrorPage from '../_error';
 import Page from '../../components/Page';
 
 import { get } from '../../getTakwimuPage';


### PR DESCRIPTION
## Description

`next/error` was being used in `[page]` which meant our custom error pages were being ignored.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation