### PR TITLE
[Hotfix] Analysis page components UI Fixes

### DIFF
--- a/src/components/AnalysisPage.js
+++ b/src/components/AnalysisPage.js
@@ -22,7 +22,9 @@ function AnalysisPage({
   initial,
   activeAnalysis,
   analyses,
-  analysisLink
+  analysisLink,
+  readNextTitle,
+  topicsNavigation
 }) {
   const classes = useStyles();
 
@@ -62,6 +64,8 @@ function AnalysisPage({
           content={activeAnalysis}
           takwimu={takwimu}
           analysisLink={analysisLink}
+          readNextTitle={readNextTitle}
+          topicsNavigation={topicsNavigation}
         />
       </ContentPage>
     </Page>
@@ -85,7 +89,9 @@ AnalysisPage.propTypes = {
       slug: PropTypes.string
     })
   }).isRequired,
-  analysisLink: PropTypes.string.isRequired
+  analysisLink: PropTypes.string.isRequired,
+  readNextTitle: PropTypes.string.isRequired,
+  topicsNavigation: PropTypes.string.isRequired
 };
 
 const get = async url => {

--- a/src/components/Footer/StayInTouch.js
+++ b/src/components/Footer/StayInTouch.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import NextLink from 'next/link';
-
-import { Grid, Link } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, Grid } from '@material-ui/core';
 
 import A from '@codeforafrica/hurumap-ui/core/A';
 
+import Link from '../Link';
 import Title from './Title';
 
 import email from '../../assets/images/email.svg';
@@ -18,6 +16,7 @@ import twitter from '../../assets/images/twitter.svg';
 
 const useStyles = makeStyles({
   root: {
+    marginTop: '3.125rem',
     width: '14.375rem'
   },
   icons: {
@@ -39,14 +38,13 @@ const useStyles = makeStyles({
 
 function StayInTouch({ settings: { support, socialMedia } }) {
   const classes = useStyles();
+
   return (
     <div className={classes.root}>
       <Title>
-        <NextLink href="/contact">
-          <Link href="/contact" variant="subtitle1" className={classes.title}>
-            Stay in touch
-          </Link>
-        </NextLink>
+        <Link href="/contact" variant="subtitle1" className={classes.title}>
+          Stay in touch
+        </Link>
       </Title>
       <Grid
         container

--- a/src/components/Footer/Support.js
+++ b/src/components/Footer/Support.js
@@ -12,6 +12,7 @@ import gates3 from '../../assets/images/gates@3x.png';
 
 const useStyles = makeStyles({
   root: {
+    marginTop: '3.125rem',
     width: '14.375rem'
   },
   img: {

--- a/src/components/TableOfContent.js
+++ b/src/components/TableOfContent.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import classNames from 'classnames';
 
-import { MenuList, Typography, Grid } from '@material-ui/core';
+import { Grid, MenuList } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import withWidth, { isWidthUp } from '@material-ui/core/withWidth';
 
@@ -20,13 +20,19 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     alignItems: 'flex-start',
     [theme.breakpoints.up('md')]: {
+      /**
+       * Since we want to negative margin for the current item image **and**
+       * overflow hidden, we'll set the negative margin on root and use padding
+       * to shift item's contents to the right
+       */
+      marginLeft: '-1.5rem',
       position: 'fixed',
       width: 'fit-content',
       top: `${DEFAULT_TOP}px`,
       bottom: 0,
       overflow: 'hidden auto',
 
-      scrollbarColor: '#d3d3d3',
+      scrollbarColor: '#d3d3d3 transparent',
       scrollbarWidth: 'thin',
       '&::-webkit-scrollbar': {
         width: '0.4rem'
@@ -39,12 +45,14 @@ const useStyles = makeStyles(theme => ({
       }
     }
   },
+  children: {
+    paddingLeft: '1.5rem'
+  },
   menuListRoot: {
     padding: 0,
     width: '14.188rem'
   },
   activeContentIndicator: {
-    marginLeft: '-1.5rem',
     marginRight: '1rem'
   },
   listItem: {
@@ -54,11 +62,13 @@ const useStyles = makeStyles(theme => ({
     display: 'flex'
   },
   linkRoot: {
+    paddingLeft: '1.5rem',
     fontWeight: 'bold',
     textDecoration: 'underline',
     color: theme.palette.primary.main
   },
   activeLink: {
+    paddingLeft: 0,
     color: theme.palette.text.primary,
     textDecoration: 'none'
   }
@@ -100,7 +110,9 @@ function TableOfContent({ children, content, current, generateHref, width }) {
       direction="column"
       wrap="nowrap"
     >
-      <Grid item>{children}</Grid>
+      <Grid item className={classes.children}>
+        {children}
+      </Grid>
       <Grid item>
         <MenuList classes={{ root: classes.menuListRoot }}>
           {content.map((c, index) => (
@@ -129,15 +141,12 @@ function TableOfContent({ children, content, current, generateHref, width }) {
                     ? generateHref(index).as
                     : undefined
                 }
+                variant="body2"
+                className={classNames(classes.linkRoot, {
+                  [classes.activeLink]: current === index
+                })}
               >
-                <Typography
-                  variant="body2"
-                  className={classNames(classes.linkRoot, {
-                    [classes.activeLink]: current === index
-                  })}
-                >
-                  {c.title}
-                </Typography>
+                {c.title}
               </Link>
             </li>
           ))}

--- a/src/theme.js
+++ b/src/theme.js
@@ -279,6 +279,19 @@ const Theme = createTheme({
           '@media (min-width: 782px)': {
             marginLeft: '32px'
           }
+        },
+        /**
+         * Override load-styles.php customizations
+         */
+        a: {
+          '&:focus': {
+            boxShadow: 'none',
+            color: 'black',
+            outline: 'none'
+          }
+        },
+        li: {
+          marginBottom: 0
         }
       }
     },


### PR DESCRIPTION
## Description

 - [x] Table of Content,
 - [x] Topics navigation,
 - [x] Read next, and
 - [x] `load-styles.php` introduced unnecessary styling to `a` and `li`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S0](https://user-images.githubusercontent.com/1779590/72527630-3edc1e00-387a-11ea-99f1-c39e142dd90f.png)

![S1](https://user-images.githubusercontent.com/1779590/72527643-456a9580-387a-11ea-9e21-4f4a41f0a135.png)

![S2](https://user-images.githubusercontent.com/1779590/72527650-48658600-387a-11ea-8382-52a9f8fcebe5.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation