### PR TITLE
[Hotfix] Year of Takwimu

### DIFF
--- a/src/components/AnalysisContent/Actions/DownloadPDF.js
+++ b/src/components/AnalysisContent/Actions/DownloadPDF.js
@@ -142,7 +142,7 @@ const createPdf = () => {
               style={classes.linkLicense}
               href="//creativecommons.org/licenses/by/4.0/"
             >
-              2018 {takwimu.name} CC by 4.0
+              2020 {takwimu.name} CC by 4.0
             </Link>
             <View style={classes.logoBackground}>
               <Image style={classes.logo} src={logoWhite} />

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -108,7 +108,7 @@ function Footer({ takwimu: { settings }, ...props }) {
         </Grid>
         <div className={classes.license}>
           <Typography variant="subtitle2" className={classes.text}>
-            2018 Takwimu{' '}
+            2020 Takwimu{' '}
             <A
               href="//creativecommons.org/licenses/by/4.0/"
               className={classes.text}

--- a/src/components/MakingOfTakwimu.js
+++ b/src/components/MakingOfTakwimu.js
@@ -63,7 +63,12 @@ function MakingOfTakwimu({
   }
 
   return (
-    <Section title={title} variant="h3" classes={{ title: classes.title }}>
+    <Section
+      id="takwimuMakingOf"
+      title={title}
+      variant="h3"
+      classes={{ title: classes.title }}
+    >
       <RichTypography>{description}</RichTypography>
       <div className={classes.container}>
         <iframe


### PR DESCRIPTION
## Description

 - [x] Change year to `2020` both on site footer and PDF downloads,
 - [x] Add `id` to **Making of Takwimu** video to be linked from site hero.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![s](https://user-images.githubusercontent.com/1779590/73182567-547afe80-412a-11ea-95de-351c39ecdebe.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation