### PR TITLE
[Hotfix] dependent Axis labels

### DIFF
--- a/src/components/ProfilePage.js
+++ b/src/components/ProfilePage.js
@@ -118,6 +118,31 @@ function Chart({ chartData, definition, profiles, classes }) {
   );
 }
 
+const overrideTypePropsFor = chartType => {
+  switch (chartType) {
+    case 'column': // Fall through
+    case 'grouped_column':
+      return {
+        parts: {
+          axis: {
+            dependent: {
+              style: {
+                grid: {
+                  display: 'none'
+                },
+                tickLabels: {
+                  display: 'none'
+                }
+              }
+            }
+          }
+        }
+      };
+    default:
+      return {};
+  }
+};
+
 function Profile({ sectionedCharts }) {
   const router = useRouter();
   const {
@@ -295,7 +320,13 @@ function Profile({ sectionedCharts }) {
                           <Chart
                             key={chart.id}
                             chartData={chartData}
-                            definition={chart.visual}
+                            definition={{
+                              ...chart.visual,
+                              typeProps: {
+                                ...chart.visual.typeProps,
+                                ...overrideTypePropsFor(chart.visual.type)
+                              }
+                            }}
                             profiles={profiles}
                             classes={classes}
                           />
@@ -317,7 +348,7 @@ function Profile({ sectionedCharts }) {
             })}
         </Grid>
       )),
-    [profileTabs, chartData, classes, country.slug, profiles, geoId]
+    [profileTabs, chartData, geoId, classes, country.slug, profiles]
   );
 
   // Show and hide sections


### PR DESCRIPTION
## Description

Takwimu designs doesn't seem to be using dependent (y-axis) charts and until we can add ability to tweak per chart appearance in the dashboard, it's best to not show them

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

![s](https://user-images.githubusercontent.com/1779590/73186962-ad9a6080-4131-11ea-8dd4-0191c0e88303.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation