### PR TITLE
[Hotfix] URL Structure

### DIFF
--- a/src/components/SearchResults/DataSearchResultItem.js
+++ b/src/components/SearchResults/DataSearchResultItem.js
@@ -60,7 +60,7 @@ function InTopicDataResult({ inTopics, item, title, visualType, chartId }) {
                   sectionSlug = profileSection[0].post_name;
                 }
                 setLink(
-                  `/profiles/${topic.countrySlug}/${sectionSlug}#${topicSlug}?indicatorId=indicator-${visualType}-${chartId}`
+                  `/profiles/${topic.countrySlug}/${sectionSlug}?indicatorId=indicator-${visualType}-${chartId}#${topicSlug}`
                 );
               }
             );


### PR DESCRIPTION
## Description

URL given for data results when found in analysis pages was incorrect; hash was put before query making query inaccessible to SSR. This PR fixes the structure to `/path?query#hash`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation