### PR TITLE
[Hotfix] Analysis Page Spacing and Chart Grid

### DIFF
--- a/src/components/CountryContent/index.js
+++ b/src/components/CountryContent/index.js
@@ -11,19 +11,19 @@ import Selection from './Selection';
 const useStyles = makeStyles(theme => ({
   root: {
     backgroundColor: theme.palette.background.light,
-    margin: '0 0 2.3125rem 0',
+    margin: '1.375rem 0 2.3125rem 0',
     paddingTop: '3.125rem',
     paddingBottom: '3.5rem',
     width: '100%',
     [theme.breakpoints.up('md')]: {
-      width: '44.015625rem', // .75 of lg
       paddingLeft: '1.625rem',
-      paddingRight: '1.625rem'
+      paddingRight: '1.625rem',
+      width: '43.734375rem' // .75 of lg
     },
     [theme.breakpoints.up('lg')]: {
-      width: '58.6875rem',
       paddingLeft: '2.8125rem',
-      paddingRight: '2.8125rem'
+      paddingRight: '2.8125rem',
+      width: '58.3125rem'
     }
   },
   title: {
@@ -68,7 +68,7 @@ const VIEW_ITEMS = [
   }
 ];
 
-function ViewAnalysis({ content, takwimu: { country, countries } }) {
+function CountryContent({ content, takwimu: { country, countries } }) {
   const classes = useStyles();
   const [countrySlug, setCountrySlug] = useState(country.slug);
   const [view, setView] = useState(VIEW_ITEMS[0].value);
@@ -128,7 +128,7 @@ function ViewAnalysis({ content, takwimu: { country, countries } }) {
   );
 }
 
-ViewAnalysis.propTypes = {
+CountryContent.propTypes = {
   content: PropTypes.shape({
     contentSelectLabel: PropTypes.string,
     countrySelectLabel: PropTypes.string,
@@ -147,4 +147,4 @@ ViewAnalysis.propTypes = {
   }).isRequired
 };
 
-export default ViewAnalysis;
+export default CountryContent;

--- a/src/components/Next/Analysis.js
+++ b/src/components/Next/Analysis.js
@@ -13,15 +13,15 @@ const useStyles = makeStyles(theme => ({
   root: {
     width: '100%',
     [theme.breakpoints.up('md')]: {
-      width: '100%'
+      width: '43.734375rem' // .75 of lg
     },
     [theme.breakpoints.up('lg')]: {
-      width: '100%'
+      width: '58.3125rem'
     }
   },
   container: {
     flexGrow: 1,
-    paddingBottom: '6.25rem'
+    paddingBottom: '0.9375rem'
   },
   cardMargin: {
     marginTop: '2rem',

--- a/src/theme.js
+++ b/src/theme.js
@@ -56,6 +56,10 @@ const theme = createTheme({
         }
       }
     },
+    dependentAxis: {
+      fixLabelOverlap: true,
+      tickCount: 3
+    },
     axis: {
       labelWidth: 100,
       style: {


### PR DESCRIPTION
## Description

- [x] Limit the number of y-axis points to avoid overlap,
- [x] Make sure content selection component has spacing even if there is no Read Next component,
- [x] Improve Read Next spacing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![s](https://user-images.githubusercontent.com/1779590/73548000-1abf3600-4451-11ea-8a84-8a35e642ff76.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation