### PR TITLE
Hierarchical Language Support

### DIFF
--- a/src/components/AnalysisPage.js
+++ b/src/components/AnalysisPage.js
@@ -129,7 +129,7 @@ const get = async url => {
 };
 
 AnalysisPage.getInitialProps = async ({
-  query: { geoIdOrCountrySlug: slug, analysisSlug },
+  query: { geoIdOrCountrySlug: slug, analysisSlug, lang: queryLang },
   asPath
 }) => {
   const { WP_BACKEND_URL, countries } = config;
@@ -138,6 +138,7 @@ AnalysisPage.getInitialProps = async ({
     config.country,
     countries.find(c => c.slug === slug)
   );
+  const lang = queryLang || config.country.lang || config.DEFAULT_LANG;
 
   let analyses = [];
   let activeAnalysis = {};
@@ -148,7 +149,7 @@ AnalysisPage.getInitialProps = async ({
 
   try {
     const [profile] = await get(
-      `${WP_BACKEND_URL}/wp-json/wp/v2/profile?slug=${slug}`
+      `${WP_BACKEND_URL}/wp-json/wp/v2/profile?slug=${slug}&lang=${lang}`
     );
 
     if (profile && profile.acf) {
@@ -187,7 +188,7 @@ AnalysisPage.getInitialProps = async ({
         const {
           acf: { section_topics: sectionTopics }
         } = await get(
-          `${WP_BACKEND_URL}/wp-json/wp/v2/profile_section_page/${activeAnalysis.ID}`
+          `${WP_BACKEND_URL}/wp-json/wp/v2/profile_section_page/${activeAnalysis.ID}?lang=${lang}`
         );
 
         const topics = await Promise.all(
@@ -199,12 +200,12 @@ AnalysisPage.getInitialProps = async ({
               const {
                 acf: { topic_carousel_body: carousel }
               } = await get(
-                `${WP_BACKEND_URL}/wp-json/wp/v2/carousel_topic/${topic.ID}`
+                `${WP_BACKEND_URL}/wp-json/wp/v2/carousel_topic/${topic.ID}?lang=${lang}`
               );
               topic.carousel = carousel; // eslint-disable-line no-param-reassign
             } else {
               const { content: { rendered } = { rendered: '' } } = await get(
-                `${WP_BACKEND_URL}/wp-json/wp/v2/topic_page/${topic.ID}`
+                `${WP_BACKEND_URL}/wp-json/wp/v2/topic_page/${topic.ID}?lang=${lang}`
               );
               topic.type = 'topic'; // eslint-disable-line no-param-reassign
               topic.content = rendered; // eslint-disable-line no-param-reassign

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,10 @@
-const WP_BACKEND_URL = 'https://dashboard.takwimu.africa';
+const WP_BACKEND_URL =
+  // eslint-disable-next-line no-nested-ternary
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:8080'
+    : process.env.NODE_ENV === 'staging'
+    ? 'https://takwimutech.wpengine.com'
+    : 'https://dashboard.takwimu.africa';
 
 const config = {
   url:

--- a/src/config.js
+++ b/src/config.js
@@ -1,10 +1,4 @@
-const WP_BACKEND_URL =
-  // eslint-disable-next-line no-nested-ternary
-  process.env.NODE_ENV === 'development'
-    ? 'http://localhost:8080'
-    : process.env.NODE_ENV === 'staging'
-    ? 'https://takwimutech.wpengine.com'
-    : 'https://dashboard.takwimu.africa';
+const WP_BACKEND_URL = 'https://dashboard.takwimu.africa';
 
 const config = {
   url:
@@ -28,6 +22,7 @@ Disallow:
     process.env.NODE_ENV === 'development'
       ? 'http://localhost:9200'
       : 'https://search-cfa-openafrica-z56l24lkfbv5erjxxs76sevr3i.eu-west-1.es.amazonaws.com',
+  DEFAULT_LANG: 'en',
   country: {},
   countries: [
     {
@@ -36,6 +31,7 @@ Disallow:
       iso_name: 'Burkina Faso',
       short_name: 'Burkina Faso',
       slug: 'burkina-faso',
+      lang: 'en',
       published: true
     },
     {
@@ -44,6 +40,7 @@ Disallow:
       iso_name: 'Congo, the Democratic Republic of the',
       short_name: 'DR Congo',
       slug: 'democratic-republic-of-congo',
+      lang: 'en',
       published: true
     },
     {
@@ -52,6 +49,7 @@ Disallow:
       iso_name: 'Ethiopia',
       short_name: 'Ethiopia',
       slug: 'ethiopia',
+      lang: 'en',
       published: true
     },
     {
@@ -60,6 +58,7 @@ Disallow:
       iso_name: 'Kenya',
       short_name: 'Kenya',
       slug: 'kenya',
+      lang: 'en',
       published: true
     },
     {
@@ -68,6 +67,7 @@ Disallow:
       iso_name: 'Nigeria',
       short_name: 'Nigeria',
       slug: 'nigeria',
+      lang: 'en',
       published: true
     },
     {
@@ -76,6 +76,7 @@ Disallow:
       iso_name: 'Senegal',
       short_name: 'Senegal',
       slug: 'senegal',
+      lang: 'fr',
       published: true
     },
     {
@@ -84,6 +85,7 @@ Disallow:
       iso_name: 'South Africa',
       short_name: 'South Africa',
       slug: 'south-africa',
+      lang: 'en',
       published: true
     },
     {
@@ -92,6 +94,7 @@ Disallow:
       iso_name: 'Tanzania, United Republic of',
       short_name: 'Tanzania',
       slug: 'tanzania',
+      lang: 'en',
       published: true
     },
     {
@@ -100,6 +103,7 @@ Disallow:
       iso_name: 'Uganda',
       short_name: 'Uganda',
       slug: 'uganda',
+      lang: 'en',
       published: true
     },
     {
@@ -108,6 +112,7 @@ Disallow:
       iso_name: 'Zambia',
       short_name: 'Zambia',
       slug: 'zambia',
+      lang: 'en',
       published: true
     }
   ],


### PR DESCRIPTION
## Description

This PR introduces a hierarchy of languages in Takwimu: Site wide default and (country) profile default. This is to support those countries that are predominantly non-English speaking. Their country profiles should by default be presented in their native language.

#96 will allow users to switch to other supported languages.

Fixes #171484798

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Screenshots

![Screenshot from 2020-02-26 09-10-36](https://user-images.githubusercontent.com/1779590/75317003-eab05a80-5877-11ea-85b3-7c24d8e09ee2.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation