### PR TITLE
Countrify based on language

### DIFF
--- a/src/components/FeaturedAnalysis/index.js
+++ b/src/components/FeaturedAnalysis/index.js
@@ -54,8 +54,7 @@ class FeaturedAnalysis extends React.Component {
 
     const countrifyTitle = (analysis, countrySlug) => {
       const { post_title: t } = analysis;
-      const country = countries.find(c => c.slug === countrySlug);
-      return countrify(t, country, countries);
+      return countrify(t, { slug: countrySlug }, countries);
     };
 
     return (

--- a/src/components/utils.js
+++ b/src/components/utils.js
@@ -1,12 +1,32 @@
 /* eslint-disable import/prefer-default-export */
+import config from '../config';
 
-export const countrify = (title, country, countries, conj = '&rsquo;s ') => {
+const DEFAULT_CONJ = ' ';
+
+export const countrify = (
+  title,
+  country,
+  countries = config.countries,
+  conj,
+  language = config.language
+) => {
   const foundCountry = countries.find(c => c.slug === country.slug);
   if (
     foundCountry &&
     !title.toLowerCase().startsWith(foundCountry.short_name.toLowerCase())
   ) {
-    return `${foundCountry.short_name}${conj}${title}`;
+    let langConj = conj;
+    if (!langConj) {
+      switch (language) {
+        case 'en':
+          langConj = '&rsquo;s ';
+          break;
+        default:
+          langConj = DEFAULT_CONJ;
+          break;
+      }
+    }
+    return `${foundCountry.short_name}${langConj}${title}`;
   }
   return title;
 };


### PR DESCRIPTION
## Description

The current `countrify` behaviour of appending `'s` to country names is only correct for `en`. Now that we support multiple languages, we should restring this behaviour to English only _for now_. 

Future versions may come up with per language `countrification`.

Delivers #171810557

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![s](https://user-images.githubusercontent.com/1779590/76741782-2d7f9700-6781-11ea-809e-65a466b0620a.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation