### PR TITLE
[Hotfix] Fetch block contents for language

### DIFF
--- a/src/components/AnalysisContent/index.js
+++ b/src/components/AnalysisContent/index.js
@@ -88,16 +88,16 @@ function AnalysisContent({
           switch (type) {
             case 'flourish':
             case 'hurumap':
-              return `${config.WP_BACKEND_URL}/wp-json/hurumap-data/charts/${id}`;
+              return `${config.WP_BACKEND_URL}/wp-json/hurumap-data/charts/${id}?lang=${takwimu.language}`;
             case 'snippet':
-              return `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}/${id}`;
+              return `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}/${id}?lang=${takwimu.language}`;
             default:
               return '';
           }
         }
       })
     );
-  }, [takwimu.country.name, content, topicIndex]);
+  }, [takwimu.country.name, takwimu.language, content, topicIndex]);
 
   const [carouselItemIndex, setCarouselItemIndex] = useState(
     content.topics &&
@@ -219,6 +219,7 @@ AnalysisContent.propTypes = {
   contentSelector: PropTypes.shape({}).isRequired,
   contentActionsLabels: PropTypes.shape({}).isRequired,
   takwimu: PropTypes.shape({
+    language: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
     page: PropTypes.shape({}).isRequired,
     country: PropTypes.shape({

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -18,6 +18,7 @@ import config from '../config';
 
 function Home({ latestMediumPosts, takwimu }) {
   const {
+    language,
     page: {
       rendered: featuredData,
       where_to_next_title: whereToNextTitle,
@@ -37,16 +38,16 @@ function Home({ latestMediumPosts, takwimu }) {
             switch (type) {
               case 'flourish':
               case 'hurumap':
-                return `${config.WP_BACKEND_URL}/wp-json/hurumap-data/charts/${id}`;
+                return `${config.WP_BACKEND_URL}/wp-json/hurumap-data/charts/${id}?lang=${language}`;
               case 'snippet':
-                return `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}/${id}`;
+                return `${config.WP_BACKEND_URL}/wp-json/wp/v2/${type}/${id}?lang=${language}`;
               default:
                 return '';
             }
           }
         })
       ),
-    []
+    [language]
   );
 
   return (
@@ -76,6 +77,7 @@ function Home({ latestMediumPosts, takwimu }) {
 Home.propTypes = {
   latestMediumPosts: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
   takwimu: PropTypes.shape({
+    language: PropTypes.string,
     page: PropTypes.shape({
       rendered: PropTypes.string,
       where_to_next_title: PropTypes.string,


### PR DESCRIPTION
## Description

On Takwimu, seems like wp-json returns the correct data for the card in french: https://dashboard.takwimu.africa/wp-json/wp/v2/topic_page?slug=health-sn&lang=fr but the front end fails: https://takwimu.africa/profiles/senegal/health-sn?lang=fr

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation