### PR TITLE
[Investigative] Add Permissive CSP to Test iframe font Loading Issue

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -43,6 +43,10 @@ export default class MyApp extends App {
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
           />
           <meta charSet="utf-8" />
+          <meta
+            httpEquiv="Content-Security-Policy"
+            content="default-src 'self' 'unsafe-inline'; img-src * data:; connect-src *; style-src * 'unsafe-eval' 'unsafe-inline'; font-src * data:; script-src-elem * 'unsafe-inline'; frame-src * data:"
+          />
         </Head>
         <ApolloProvider client={client}>
           <StylesProvider jss={MyApp.jss}>


### PR DESCRIPTION
## Description

Font loading fails when downloading/sharing iframe due to security issues. This PR adds a permissive Content Security Policy to try and resolve that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation