### PR TITLE
[Investigative] Remove CSP

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -43,10 +43,6 @@ export default class MyApp extends App {
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
           />
           <meta charSet="utf-8" />
-          <meta
-            httpEquiv="Content-Security-Policy"
-            content="default-src * 'unsafe-inline'; img-src * data:; connect-src *; style-src * 'unsafe-eval' 'unsafe-inline'; font-src * data:; script-src-elem * 'unsafe-inline'; frame-src * data: 'unsafe-inline'"
-          />
         </Head>
         <ApolloProvider client={client}>
           <StylesProvider jss={MyApp.jss}>


### PR DESCRIPTION
## Description

Looks like Content Security Policy won't help with iframe font loading issue: Essential we have no control of the html content from the iframe and it loads google font without setting `crossorign="anonymous"`

https://github.com/tsayen/dom-to-image/issues/205#issuecomment-512328517

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation