### PR TITLE
[HotFix] Remove Usage of stories.hurumap.org

### DIFF
--- a/src/components/LatestNewsStories/StoryBlocks.js
+++ b/src/components/LatestNewsStories/StoryBlocks.js
@@ -33,7 +33,7 @@ function StoryBlocks({ stories }) {
     <Grid container className={classes.root} spacing={0}>
       {stories.slice(0, 3).map((story, index) => (
         <StoryCard
-          key={story.id}
+          key={story.uniqueSlug}
           story={{
             previewImageUrl: `https://cdn-images-1.medium.com/max/480/${story.virtuals.previewImage.imageId}`,
             subtitle: story.content.subtitle,
@@ -47,7 +47,7 @@ function StoryBlocks({ stories }) {
       ))}
       {stories.slice(0, 3).map((story, index) => (
         <StorySummary
-          key={story.id}
+          key={story.uniqueSlug}
           subtitle={story.content.subtitle}
           classes={{
             root: classNames([classes.story, { [classes.margin]: index > 0 }])

--- a/src/components/LatestNewsStories/StoryList.js
+++ b/src/components/LatestNewsStories/StoryList.js
@@ -17,8 +17,9 @@ const useStyles = makeStyles({
   }
 });
 
-function StoryList({ stories }) {
-  const classes = useStyles();
+function StoryList({ stories, ...props }) {
+  const classes = useStyles(props);
+
   return (
     <Grid
       container
@@ -28,7 +29,7 @@ function StoryList({ stories }) {
     >
       {stories.slice(0, 3).map((story, index) => (
         <Story
-          key={story.link}
+          key={story.uniqueSlug}
           story={{
             previewImageUrl: `https://cdn-images-1.medium.com/max/480/${story.virtuals.previewImage.imageId}`,
             subtitle: story.content.subtitle,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,6 +14,7 @@ import Page from '../components/Page';
 import WhatYouDoWithTakwimu from '../components/WhatYouCanDoWithTakwimu';
 import WhereToNext from '../components/Next';
 import Section from '../components/Section';
+import fetchStories from '../utils/fetchStories';
 import config from '../config';
 
 function Home({ latestMediumPosts, takwimu }) {
@@ -91,8 +92,7 @@ Home.getInitialProps = async props => {
     query: { lang: pageLanguage }
   } = props;
   const lang = pageLanguage || config.DEFAULT_LANG;
-  const res = await fetch('https://stories.hurumap.org/@takwimu_africa/latest');
-  const latestMediumPosts = await res.json();
+  const latestMediumPosts = await fetchStories();
   const takwimu = await getSitePage('index', lang);
 
   return {

--- a/src/utils/fetchStories.js
+++ b/src/utils/fetchStories.js
@@ -1,0 +1,21 @@
+import config from '../config';
+
+export default async function fetchStories() {
+  const urlJson = `https://corsio.devops.codeforafrica.org/?${config.stories.url}?format=json`;
+  const response = await fetch(urlJson);
+  const jsonClean = await (await response.text()).replace(
+    '])}while(1);</x>',
+    ''
+  );
+  const json = await JSON.parse(jsonClean);
+  const reportStreamItems = await json.payload.streamItems;
+  // console.log('BOOM', { json, reportStreamItems });
+  const reports = await reportStreamItems.map(
+    reportStreamItem =>
+      reportStreamItem.postPreview &&
+      json.payload.references.Post[reportStreamItem.postPreview.postId]
+  );
+
+  // Remove null stories
+  return reports.filter(story => story);
+}

--- a/src/utils/fetchStories.js
+++ b/src/utils/fetchStories.js
@@ -9,7 +9,6 @@ export default async function fetchStories() {
   );
   const json = await JSON.parse(jsonClean);
   const reportStreamItems = await json.payload.streamItems;
-  // console.log('BOOM', { json, reportStreamItems });
   const reports = await reportStreamItems.map(
     reportStreamItem =>
       reportStreamItem.postPreview &&


### PR DESCRIPTION
## Description

Remove usage of stories.hurumap.org when fetching latest stories. Fetch stories directly from source.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

![Screenshot_2020-06-11 Takwimu](https://user-images.githubusercontent.com/1779590/84402519-301d4b80-ac0d-11ea-8f43-69c31af7164a.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation